### PR TITLE
Fixes TOMAS build for GEOS-Chem Classic

### DIFF
--- a/CMakeScripts/GC-ConfigureClassic.cmake
+++ b/CMakeScripts/GC-ConfigureClassic.cmake
@@ -95,7 +95,7 @@ function(configureGCClassic)
     # Build TOMAS
     #-------------------------------------------------------------------------
     set(TOMAS "OFF" CACHE BOOL "Switch to enable TOMAS")
-    set(TOMAS_BINS "NA" CACHE BOOL "Number of TOMAS bins (only used if TOMAS is true)")
+    set(TOMAS_BINS "NA" CACHE STRING "Number of TOMAS bins (only used if TOMAS is true)")
     gc_pretty_print(VARIABLE TOMAS IS_BOOLEAN)
     gc_pretty_print(VARIABLE TOMAS_BINS OPTIONS "NA" "15" "40")
     if(${TOMAS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,13 @@
 # Tell CMake to look for code in HEMCO and GEOS-Chem directory trees
 #-----------------------------------------------------------------------------
 add_subdirectory(HEMCO     EXCLUDE_FROM_ALL)
+target_compile_definitions(HEMCOBuildProperties 
+    INTERFACE 
+        $<$<BOOL:${TOMAS}>:TOMAS>
+        $<$<STREQUAL:${TOMAS_BINS},15>:TOMAS15>
+        $<$<STREQUAL:${TOMAS_BINS},40>:TOMAS40>
+        ""
+)
 add_subdirectory(GEOS-Chem EXCLUDE_FROM_ALL)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
@yantosca's integration tests identified that the TOMAS builds were broken following #8.

The issue was that some module in HEMCO need the `-DTOMAS` and `-DTOMAS15` definitions, but #8 decoupled the compiler options of GCClassic and HEMCO, so those HEMCO modules were no longer getting the tomas definitions. This fixes that.

This is OK to merge at any time.