### PR TITLE
No default for RUNDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ if(NOT GC_EXTERNAL_CONFIG)
     gc_pretty_print(SECTION "Run directory setup")
 
    # Run directory
-   set(RUNDIR ".." CACHE PATH "Path(s) to run directory (semicolon separated list). Specifies install locations for gchp")
+   set(RUNDIR "" CACHE PATH "Path(s) to run directory (semicolon separated list). Specifies install locations for gchp")
    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Fake CMAKE_INSTALL_PREFIX (use RUNDIR instead)" FORCE)
    set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE)
    gc_pretty_print(VARIABLE RUNDIR)


### PR DESCRIPTION
At last weeks GCST telecon, we decided it was okay to have no default value for `RUNDIR`. This PR makes this update.

To achieve the previous behaviour you would do

`cmake /path/to/your/source/code -DRUNDIR=".."`

The purpose of this change is to remove this implicit behaviour because it (1) is no longer necessary to inspect the run directory to configure the build, (2) makes it easier to teach compiling GEOS-Chem since it can be described independent of the run directory, and (3) implies GEOS-Chem needs to be built separately for each run directory. 


This is OK to merge. It's a trival change, but it does affect the build's default behaviour. 