### PR TITLE
Update CI tests to use the new geoschem/buildmatrix images.

### DIFF
--- a/.ci-pipelines/build-matrix.yml
+++ b/.ci-pipelines/build-matrix.yml
@@ -32,30 +32,14 @@ pool:
 # Define the "matrix" of build images to try building GEOS-Chem in
 strategy:
   matrix:
-    ubuntu_gcc6:
-      GCC_VERSION: 6
-      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc6-netcdf4.5.0-netcdff4.4.4
-    ubuntu_gcc7:
-      GCC_VERSION: 7
-      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc7-netcdf4.5.0-netcdff4.4.4
-    ubuntu_gcc8:
-      GCC_VERSION: 8
-      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc8-netcdf4.5.0-netcdff4.4.4
-    ubuntu_gcc9:
-      GCC_VERSION: 9
-      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-gcc9-netcdf4.5.0-netcdff4.4.4
-    ubuntu_netcdf_new:
-      GCC_VERSION: 9
-      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-netcdf4.7.1-netcdff4.5.2
-    ubuntu_netcdf_old:
-      GCC_VERSION: 9
-      containerImage: liambindle/penelope:0.1.0-ubuntu16.04-netcdf4.1.3
-    centos_gcc7:
-      GCC_VERSION: 7
-      containerImage: liambindle/penelope:0.1.0-centos7-gcc7-netcdf4.5.0-netcdff4.4.4
-    centos_gcc8:
-      GCC_VERSION: 8
-      containerImage: liambindle/penelope:0.1.0-centos7-gcc8-netcdf4.5.0-netcdff4.4.4
+    ubuntu_basic:
+      containerImage: geoschem/buildmatrix:netcdf-ubuntu
+    gcc8:
+      containerImage: geoschem/buildmatrix:netcdf-gcc8
+    gcc9:
+      containerImage: geoschem/buildmatrix:netcdf-gcc9
+    gcc10:
+      containerImage: geoschem/buildmatrix:netcdf-gcc10
 container: $[ variables['containerImage'] ]
 
 
@@ -64,14 +48,16 @@ steps:
 - checkout: self
   submodules: true
 - script: |
-    source /init.rc
-    module load gcc/${GCC_VERSION}
-    spack load hdf5
-    spack load netcdf
+    . /opt/spack/share/spack/setup-env.sh
+    export CC=gcc
+    export CXX=g++
+    export FC=gfortran
+    set -x
+    spack load cmake
+    spack load netcdf-c
     spack load netcdf-fortran
-    git -c $(Build.Repository.LocalPath) submodule update --init --recursive
     mkdir build
     cd build
-    cmake -DRUNDIR=IGNORE -DRUNDIR_SIM=fullchem -DCMAKE_COLOR_MAKEFILE=FALSE $(Build.Repository.LocalPath)
+    cmake -DCMAKE_COLOR_MAKEFILE=FALSE $(Build.Repository.LocalPath)
     make -j
   displayName: 'Building GEOS-Chem'

--- a/.ci-pipelines/quick-build.yml
+++ b/.ci-pipelines/quick-build.yml
@@ -24,7 +24,7 @@ pr:
 # Basic agent and container set up
 pool:
   vmImage: 'ubuntu-latest'
-container: liambindle/penelope:0.1.0-centos7-gcc8-netcdf4.5.0-netcdff4.4.4
+container: geoschem/buildmatrix:netcdf-ubuntu
 
 
 # Try building GEOS-Chem
@@ -32,14 +32,16 @@ steps:
 - checkout: self
   submodules: true
 - script: |
-    source /init.rc
-    module load gcc/8
-    spack load hdf5
-    spack load netcdf
+    . /opt/spack/share/spack/setup-env.sh
+    export CC=gcc
+    export CXX=g++
+    export FC=gfortran
+    set -x
+    spack load cmake
+    spack load netcdf-c
     spack load netcdf-fortran
-    git -c $(Build.Repository.LocalPath) submodule update --init --recursive
     mkdir build
     cd build
-    cmake -DRUNDIR=IGNORE -DRUNDIR_SIM=fullchem -DCMAKE_COLOR_MAKEFILE=FALSE $(Build.Repository.LocalPath)
+    cmake -DCMAKE_COLOR_MAKEFILE=FALSE $(Build.Repository.LocalPath)
     make -j
   displayName: 'Building GEOS-Chem'


### PR DESCRIPTION
This PR fixes the quick-build and build-matrix CI pipelines. The pipelines now use the new [geoschem/buildmatrix](https://hub.docker.com/r/geoschem/buildmatrix) images that are generated by [geoschem/BuildMatrixImageGenerator](https://github.com/geoschem/BuildMatrixImageGenerator).

Currently the build matrix covers GCC 8, 9, and 10. I will build and push images for 6 and 7 when I have a chance (they're easy to add to build-matrix once they're on DockerHub).

This PR can be merged immediately.

