### PR TITLE
Feature: Github action for triggering cloud benchmarks

### DIFF
--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           export NAME_SUFFIX="${GITHUB_REF}_${GITHUB_SHA}"
           export WORKFLOW_ARN=$(aws stepfunctions list-state-machines \
+            --output text \
             --query 'stateMachines[?name==`benchmarks-cloud-workflow`].stateMachineArn | [0]')
           aws stepfunctions start-execution \
             --state-machine-arn ${WORKFLOW_ARN} \

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -18,24 +18,34 @@ name: cloud_benchmarking
 on:
   push:
     branches:
-      - feature/cloud-benchmarking-workflow
+      - dev
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - dev
 
 jobs:
   trigger_step_function:
     runs-on: ubuntu-latest # aws cli comes pre-installed
     steps:
+      # conditionally set step function variables based on whether a tag or commit
+      # for now both use Spot instances -- may need to update to use on demand
       - name: Set Variables For Tags
+        # We do a 1Month benchmark for tags
         run: |
           echo "TIME_PERIOD=1Mon" >> $GITHUB_ENV
           echo "STEP_FN_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/')
       - name: Set Variables For Commits
+        # We do a 1Day benchmark for tags
         run: |
           echo "TIME_PERIOD=1Day" >> $GITHUB_ENV
           echo "STEP_FN_NAME=${GITHUB_SHA}" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/heads/')
       - name: Trigger Step Function
         env:
+          # Set config options for aws cli
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -42,14 +42,13 @@ jobs:
 
         # Note the step function input is sent in as a single json string
         run: |
-          export NAME_SUFFIX="${GITHUB_REF}_${GITHUB_SHA}"
           export WORKFLOW_ARN=$(aws stepfunctions list-state-machines \
             --output text \
             --query 'stateMachines[?name==`benchmarks-cloud-workflow`].stateMachineArn | [0]')
           aws stepfunctions start-execution \
             --state-machine-arn ${WORKFLOW_ARN} \
             --input "{\"event\": {"`
-                `"\"nameSuffix\": \"${NAME_SUFFIX}\","`
+                `"\"nameSuffix\": \"${GITHUB_SHA}\","`
                 `"\"simulationType\": \"GCC\","`
                 `"\"runType\": \"SPOT\","`
                 `"\"timePeriod\": \"1Day\","`

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -47,14 +47,14 @@ jobs:
             --output text \
             --query 'stateMachines[?name==`benchmarks-cloud-workflow`].stateMachineArn | [0]')
           aws stepfunctions start-execution \
-            --name ${STEP_FN_NAME}
+            --name ${STEP_FN_NAME} \
             --state-machine-arn ${WORKFLOW_ARN} \
             --input "{\"event\": {"`
                 `"\"nameSuffix\": \"${GITHUB_SHA}\","`
                 `"\"simulationType\": \"GCC\","`
                 `"\"runType\": \"SPOT\","`
                 `"\"timePeriod\": \"${TIME_PERIOD}\","`
-                `"\"tag\": \"${GITHUB_SHA}\","`
+                `"\"tag\": \"${STEP_FN_NAME}\","`
                 `"\"numCores\": \"48\","`
                 `"\"memory\": \"16000\","` 
                 `"\"resolution\": \"24\","`

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -24,15 +24,14 @@ jobs:
   trigger_step_function:
     runs-on: ubuntu-latest # aws cli comes pre-installed
     steps:
-      - uses: actions/checkout@v2
-      - name: Get release tag
-        id: vars
+      - name: Set Time Period
         run: |
-          GEOSCHEM_VERSION=${GITHUB_REF#refs/*/}
-          echo ::set-output name=release_tag::${GEOSCHEM_VERSION}
-          cd ${GITHUB_WORKSPACE}
-          git checkout $GEOSCHEM_VERSION
-          echo ::set-output name=release_sha::$(git rev-list -n 1 $GEOSCHEM_VERSION)
+          echo "TIME_PERIOD=1Mon" >> $GITHUB_ENV
+        if: startsWith(github.ref, 'refs/tags/')
+      - name: Set Time Period
+        run: |
+          echo "TIME_PERIOD=1Day" >> $GITHUB_ENV
+        if: startsWith(github.ref, 'refs/heads/')
       - name: Trigger Step Function
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -51,11 +50,12 @@ jobs:
                 `"\"nameSuffix\": \"${GITHUB_SHA}\","`
                 `"\"simulationType\": \"GCC\","`
                 `"\"runType\": \"SPOT\","`
-                `"\"timePeriod\": \"1Day\","`
+                `"\"timePeriod\": \"${TIME_PERIOD}\","`
                 `"\"tag\": \"${GITHUB_SHA}\","`
                 `"\"numCores\": \"48\","`
                 `"\"memory\": \"16000\","` 
                 `"\"resolution\": \"24\","`
+                `"\"sendEmailNotification\": \"true\","`
                 `"\"updateInputData\": \"0\""`
               `"}}"
       

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -18,7 +18,7 @@ name: cloud_benchmarking
 on:
   push:
     branches:
-      - dev
+      - feature/cloud-benchmarking-workflow
 
 jobs:
   trigger_step_function:
@@ -39,7 +39,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
           AWS_DEFAULT_OUTPUT: json
-          
+
         # Note the step function input is sent in as a single json string
         run: |
           NAME_SUFFIX = "${GITHUB_REF}_${GITHUB_SHA}"

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -24,13 +24,15 @@ jobs:
   trigger_step_function:
     runs-on: ubuntu-latest # aws cli comes pre-installed
     steps:
-      - name: Set Time Period
+      - name: Set Variables For Tags
         run: |
           echo "TIME_PERIOD=1Mon" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/')
-      - name: Set Time Period
+      - name: Set Variables For Commits
         run: |
           echo "TIME_PERIOD=1Day" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=${GITHUB_SHA}" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/heads/')
       - name: Trigger Step Function
         env:
@@ -45,6 +47,7 @@ jobs:
             --output text \
             --query 'stateMachines[?name==`benchmarks-cloud-workflow`].stateMachineArn | [0]')
           aws stepfunctions start-execution \
+            --name ${STEP_FN_NAME}
             --state-machine-arn ${WORKFLOW_ARN} \
             --input "{\"event\": {"`
                 `"\"nameSuffix\": \"${GITHUB_SHA}\","`

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -29,20 +29,19 @@ jobs:
   trigger_step_function:
     runs-on: ubuntu-latest # aws cli comes pre-installed
     steps:
-      # conditionally set step function variables based on whether a tag or commit
       # for now both use Spot instances -- may need to update to use on demand
-      - name: Set Variables For Tags
+      - name: Set Initial Variables
+        # By default we use 1Day benchmarks
+        run: |
+          echo "TIME_PERIOD=1Day" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=${GITHUB_SHA}" >> $GITHUB_ENV
+      # conditionally overwrite variables if a tag was the triggering event
+      - name: Reset Variables For Tags
         # We do a 1Month benchmark for tags
         run: |
           echo "TIME_PERIOD=1Mon" >> $GITHUB_ENV
           echo "STEP_FN_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/')
-      - name: Set Variables For Commits
-        # We do a 1Day benchmark for tags
-        run: |
-          echo "TIME_PERIOD=1Day" >> $GITHUB_ENV
-          echo "STEP_FN_NAME=${GITHUB_SHA}" >> $GITHUB_ENV
-        if: startsWith(github.ref, 'refs/heads/')
       - name: Trigger Step Function
         env:
           # Set config options for aws cli

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -43,8 +43,8 @@ jobs:
         # Note the step function input is sent in as a single json string
         run: |
           export NAME_SUFFIX="${GITHUB_REF}_${GITHUB_SHA}"
-          export WORKFLOW_ARN=aws stepfunctions list-state-machines \
-            --query 'stateMachines[?name==`benchmarks-cloud-workflow`].stateMachineArn | [0]'
+          export WORKFLOW_ARN=$(aws stepfunctions list-state-machines \
+            --query 'stateMachines[?name==`benchmarks-cloud-workflow`].stateMachineArn | [0]')
           aws stepfunctions start-execution \
             --state-machine-arn ${WORKFLOW_ARN} \
             --input "{\"event\": {"`

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -42,8 +42,8 @@ jobs:
 
         # Note the step function input is sent in as a single json string
         run: |
-          NAME_SUFFIX = "${GITHUB_REF}_${GITHUB_SHA}"
-          WORKFLOW_ARN = aws stepfunctions list-state-machines \
+          export NAME_SUFFIX="${GITHUB_REF}_${GITHUB_SHA}"
+          export WORKFLOW_ARN=aws stepfunctions list-state-machines \
             --query 'stateMachines[?name==`benchmarks-cloud-workflow`].stateMachineArn | [0]'
           aws stepfunctions start-execution \
             --state-machine-arn ${WORKFLOW_ARN} \

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -1,0 +1,61 @@
+# Release pipeline:
+# 
+# This pipeline triggers the cloud-based benchmarking workflow
+# upon pushes to the dev environment. The benchmarking workflow 
+# infrastructure code can be found in the following repository:
+# https://github.com/geoschem/gc-cloud-infrastructure
+#
+# This pipeline is triggered by pushes to dev
+#
+# Notes:
+#   - This workflow requires aws credentials necessary to
+#     trigger the benchmarking step function via the aws cli. 
+#     The credentials need step function permissions and can 
+#     be added to the repo as an action secret called 
+#     AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID.
+
+name: cloud_benchmarking
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  trigger_step_function:
+    runs-on: ubuntu-latest # aws cli comes pre-installed
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get release tag
+        id: vars
+        run: |
+          GEOSCHEM_VERSION=${GITHUB_REF#refs/*/}
+          echo ::set-output name=release_tag::${GEOSCHEM_VERSION}
+          cd ${GITHUB_WORKSPACE}
+          git checkout $GEOSCHEM_VERSION
+          echo ::set-output name=release_sha::$(git rev-list -n 1 $GEOSCHEM_VERSION)
+      - name: Trigger Step Function
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_DEFAULT_OUTPUT: json
+          
+        # Note the step function input is sent in as a single json string
+        run: |
+          NAME_SUFFIX = "${GITHUB_REF}_${GITHUB_SHA}"
+          WORKFLOW_ARN = aws stepfunctions list-state-machines \
+            --query 'stateMachines[?name==`benchmarks-cloud-workflow`].stateMachineArn | [0]'
+          aws stepfunctions start-execution \
+            --state-machine-arn ${WORKFLOW_ARN} \
+            --input "{\"event\": {"`
+                `"\"nameSuffix\": \"${NAME_SUFFIX}\","`
+                `"\"simulationType\": \"GCC\","`
+                `"\"runType\": \"SPOT\","`
+                `"\"timePeriod\": \"1Day\","`
+                `"\"tag\": \"${GITHUB_SHA}\","`
+                `"\"numCores\": \"48\","`
+                `"\"memory\": \"16000\","` 
+                `"\"resolution\": \"24\","`
+                `"\"updateInputData\": \"0\""`
+              `"}}"
+      


### PR DESCRIPTION
This PR creates a github action which:
- triggers a 1Day benchmark for commits and prs to dev
- triggers a 1Month benchmark for newly created tags
Currently the cloud benchmark will kick off with Spot instances. We may need to revisit whether to use on demand instances for the 1Month benchmarks