### PR TITLE
Feature/benchmarking updates: trigger 1Hr runs and use short commit hash

### DIFF
--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -19,7 +19,6 @@ on:
   push:
     branches:
       - dev
-      - feature/benchmarking-updates
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - dev
+      - feature/benchmarking-updates
     tags:
       - '*'
   pull_request:
@@ -34,7 +35,8 @@ jobs:
         # By default we use 1Day benchmarks
         run: |
           echo "TIME_PERIOD=1Hr" >> $GITHUB_ENV
-          echo "STEP_FN_NAME=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+          echo "GITHUB_SHA_SHORT=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=${GITHUB_SHA_SHORT}" >> $GITHUB_ENV
       # conditionally overwrite variables if a tag was the triggering event
       - name: Reset Variables For Tags
         # We do a 1Month benchmark for tags
@@ -61,7 +63,7 @@ jobs:
             --name ${STEP_FN_NAME} \
             --state-machine-arn ${WORKFLOW_ARN} \
             --input "{\"event\": {"`
-                `"\"nameSuffix\": \"${GITHUB_SHA}\","`
+                `"\"nameSuffix\": \"${GITHUB_SHA_SHORT}\","`
                 `"\"simulationType\": \"gcc\","`
                 `"\"runType\": \"${EC2_TYPE}\","`
                 `"\"timePeriod\": \"${TIME_PERIOD}\","`

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -34,7 +34,7 @@ jobs:
         # By default we use 1Day benchmarks
         run: |
           echo "TIME_PERIOD=1Hr" >> $GITHUB_ENV
-          echo "STEP_FN_NAME=`git rev-parse --short HEAD`" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
       # conditionally overwrite variables if a tag was the triggering event
       - name: Reset Variables For Tags
         # We do a 1Month benchmark for tags

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Set Initial Variables
         # By default we use 1Day benchmarks
         run: |
-          echo "TIME_PERIOD=1Day" >> $GITHUB_ENV
-          echo "STEP_FN_NAME=${GITHUB_SHA}" >> $GITHUB_ENV
+          echo "TIME_PERIOD=1Hr" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=`git rev-parse --short HEAD`" >> $GITHUB_ENV
       # conditionally overwrite variables if a tag was the triggering event
       - name: Reset Variables For Tags
         # We do a 1Month benchmark for tags
@@ -62,14 +62,13 @@ jobs:
             --state-machine-arn ${WORKFLOW_ARN} \
             --input "{\"event\": {"`
                 `"\"nameSuffix\": \"${GITHUB_SHA}\","`
-                `"\"simulationType\": \"GCC\","`
+                `"\"simulationType\": \"gcc\","`
                 `"\"runType\": \"${EC2_TYPE}\","`
                 `"\"timePeriod\": \"${TIME_PERIOD}\","`
                 `"\"tag\": \"${STEP_FN_NAME}\","`
                 `"\"numCores\": \"${NUM_CORES}\","`
-                `"\"memory\": \"16000\","` 
+                `"\"memory\": \"40000\","` 
                 `"\"resolution\": \"24\","`
-                `"\"sendEmailNotification\": \"true\","`
-                `"\"updateInputData\": \"0\""`
+                `"\"sendEmailNotification\": \"true\""`
               `"}}"
       

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -29,18 +29,19 @@ jobs:
   trigger_step_function:
     runs-on: ubuntu-latest # aws cli comes pre-installed
     steps:
-      - name: Show GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
       # for now both use Spot instances -- may need to update to use on demand
       - name: Set Initial Variables
         # By default we use 1Day benchmarks
         run: |
           echo "TIME_PERIOD=1Hr" >> $GITHUB_ENV
+          echo "GITHUB_SHA_SHORT=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
+      # conditionally overwrite variables if a tag was the triggering event
+      - name: Reset Initial Variables for pull request
+        run: |
           echo "GITHUB_SHA_SHORT=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
           echo "STEP_FN_NAME=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
-      # conditionally overwrite variables if a tag was the triggering event
+        if: github.event_name == 'pull_request'
       - name: Reset Variables For Tags
         # We do a 1Month benchmark for tags
         run: |

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "TIME_PERIOD=1Hr" >> $GITHUB_ENV
           echo "GITHUB_SHA_SHORT=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
-          echo "STEP_FN_NAME=${GITHUB_SHA_SHORT}" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
       # conditionally overwrite variables if a tag was the triggering event
       - name: Reset Variables For Tags
         # We do a 1Month benchmark for tags

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -29,13 +29,17 @@ jobs:
   trigger_step_function:
     runs-on: ubuntu-latest # aws cli comes pre-installed
     steps:
+      - name: Show GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       # for now both use Spot instances -- may need to update to use on demand
       - name: Set Initial Variables
         # By default we use 1Day benchmarks
         run: |
           echo "TIME_PERIOD=1Hr" >> $GITHUB_ENV
-          echo "GITHUB_SHA_SHORT=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
-          echo "STEP_FN_NAME=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
+          echo "GITHUB_SHA_SHORT=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
+          echo "STEP_FN_NAME=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV
       # conditionally overwrite variables if a tag was the triggering event
       - name: Reset Variables For Tags
         # We do a 1Month benchmark for tags


### PR DESCRIPTION
This PR updates the github action for triggering benchmarks on aws. The updates include:
- Updating the workflow commits to set off 1Hr runs instead of 1Day
- bumping up the amount of memory. As the new appears to have greater memory requirements.
- updating to use the shortened commit hash for legibility