### PR TITLE
[PULL REQUEST] Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+This file documents all notable changes to the GEOS-Chem Classic wrapper repository since version 13.4.1. See also CHANGELOG files for individual submodules:
+- src/geos-chem/CHANGELOG.md
+- src/HEMCO/CHANGELOG.md
 
-See also: src/geos-chem/CHANGELOG.md; src/HEMCO/CHANGELOG.md.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased 14.0.0]
 ### Added
-- GEOS-Chem User Manual on ReadTheDocs
+- Added files for GEOS-Chem User Manual on ReadTheDocs
+- Created CHANGELOG.md
 
 ### Changed
-- Updated CONTRIBUTING.md and SUPPORT.md with info from the GEOS-Chem wiki
+- Changed GEOS-Chem submodule to 14.0.0 release
+- Changed HEMCO submodule to 3.5.0 release
+- Updated CONTRIBUTING.md and SUPPORT.md to retire guidelines on GEOS-Chem wiki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+See also: src/geos-chem/CHANGELOG.md; src/HEMCO/CHANGELOG.md.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased 14.0.0]
+### Added
+- GEOS-Chem User Manual on ReadTheDocs
+
+### Changed
+- Updated CONTRIBUTING.md and SUPPORT.md with info from the GEOS-Chem wiki


### PR DESCRIPTION
This PR adds `CHANGELOG.md` to the GCClassic repository. This file follows the format outlined at https://keepachangelog.com/en/1.0.0/. It also only documents changes in the GCClassic wrapper and instructs users to view CHANGELOG.md files in the submodules for changes there.