### PR TITLE
Cloud-J in GEOS-Chem Classic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "docs/source/geos-chem-shared-docs"]
 	path = docs/source/geos-chem-shared-docs
 	url = https://github.com/geoschem/geos-chem-shared-docs.git
+[submodule "src/Cloud-J"]
+	path = src/Cloud-J
+	url = https://github.com/geoschem/Cloud-J.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Updated GEOS-Chem submodule to 14.3.0
 
+### Added
+- Added Cloud-J submodule which is the new default photolysis package used in GEOS-Chem
+- Added compile option FASTJX to use legacy FAST-JX photolysis in GEOS-Chem instead of Cloud-J
+
 ## [14.2.3] - 2023-12-01
 ### Added
 - Script `.release/changeVersionNumbers.sh` to change version numbers before a new GEOS-Chem Classic release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ endif()
 set(GCCLASSIC_WRAPPER TRUE)
 set(GC_EXTERNAL_CONFIG FALSE)
 set(HEMCO_EXTERNAL_CONFIG TRUE)
+set(CLOUDJ_EXTERNAL_CONFIG TRUE)
 
 #-----------------------------------------------------------------------------
 # Add the directory with source code

--- a/CMakeScripts/GC-ConfigureClassic.cmake
+++ b/CMakeScripts/GC-ConfigureClassic.cmake
@@ -203,6 +203,19 @@ function(configureGCClassic)
     endif()
 
     #-------------------------------------------------------------------------
+    # Use Cloud-J rather than Fast-J?
+    #-------------------------------------------------------------------------
+    set(CLOUDJ "OFF" CACHE BOOL
+        "Switch to enable using Cloud-J"
+    )
+    gc_pretty_print(VARIABLE CLOUDJ IS_BOOLEAN)
+    if(${CLOUDJ})
+        target_compile_definitions(GEOSChemBuildProperties
+	    INTERFACE CLOUDJ
+	)
+    endif()
+
+    #-------------------------------------------------------------------------
     # Export the following variables to GEOS-Chem directory's scope
     #-------------------------------------------------------------------------
     set(GCHP                    FALSE                       PARENT_SCOPE)
@@ -214,6 +227,7 @@ function(configureGCClassic)
     set(GTMM                    ${GTMM}                     PARENT_SCOPE)
     set(LUO_WETDEP              ${LUO_WETDEP}               PARENT_SCOPE)
     set(SANITIZE                ${SANITIZE}                 PARENT_SCOPE)
+    set(CLOUDJ                  ${CLOUDJ}                   PARENT_SCOPE)
 
     #-------------------------------------------------------------------------
     # Export information about Git status

--- a/CMakeScripts/GC-ConfigureClassic.cmake
+++ b/CMakeScripts/GC-ConfigureClassic.cmake
@@ -203,16 +203,17 @@ function(configureGCClassic)
     endif()
 
     #-------------------------------------------------------------------------
-    # Use Cloud-J rather than Fast-J?
+    # Use Fast-JX rather than Cloud-J?
     #-------------------------------------------------------------------------
-    set(CLOUDJ "OFF" CACHE BOOL
-        "Switch to enable using Cloud-J"
+
+    set(FASTJX OFF CACHE BOOL
+        "Switch to use legacy FAST-JX in GEOS-Chem"
     )
-    gc_pretty_print(VARIABLE CLOUDJ IS_BOOLEAN)
-    if(${CLOUDJ})
+    gc_pretty_print(VARIABLE FASTJX IS_BOOLEAN)
+    if(${FASTJX})
         target_compile_definitions(GEOSChemBuildProperties
-	    INTERFACE CLOUDJ
-	)
+            INTERFACE FASTJX
+        )
     endif()
 
     #-------------------------------------------------------------------------
@@ -227,7 +228,7 @@ function(configureGCClassic)
     set(GTMM                    ${GTMM}                     PARENT_SCOPE)
     set(LUO_WETDEP              ${LUO_WETDEP}               PARENT_SCOPE)
     set(SANITIZE                ${SANITIZE}                 PARENT_SCOPE)
-    set(CLOUDJ                  ${CLOUDJ}                   PARENT_SCOPE)
+    set(FASTJX                  ${FASTJX}                   PARENT_SCOPE)
 
     #-------------------------------------------------------------------------
     # Export information about Git status

--- a/CMakeScripts/summarize_build
+++ b/CMakeScripts/summarize_build
@@ -71,6 +71,7 @@ print_item_highlight RRTMG $(scrape_cache RRTMG)
 print_item_highlight GTMM $(scrape_cache GTMM)
 print_item_highlight HCOSA $(scrape_cache HCOSA)
 print_item_highlight LUO_WETDEP $(scrape_cache LUO_WETDEP)
+print_item_highlight FASTJX $(scrape_cache FASTJX)
 echo ""
 
 # grep --color "GEOSChem_Fortran_FLAGS_[A-Z_]*${COMPILER_ID}" $CACHEFILE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # src/CMakeLists.txt
 
 #-----------------------------------------------------------------------------
-# Tell CMake to look for code in HEMCO and GEOS-Chem directory trees
+# Tell CMake to look for code in HEMCO, Cloud-J and GEOS-Chem directory trees
 #-----------------------------------------------------------------------------
 add_subdirectory(HEMCO     EXCLUDE_FROM_ALL)
 target_compile_definitions(HEMCOBuildProperties
@@ -11,6 +11,9 @@ target_compile_definitions(HEMCOBuildProperties
         $<$<STREQUAL:${TOMAS_BINS},40>:TOMAS40>
         ""
 )
+if(${CLOUDJ})
+    add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
+endif()
 add_subdirectory(GEOS-Chem EXCLUDE_FROM_ALL)
 
 #-----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,7 @@ target_compile_definitions(HEMCOBuildProperties
         $<$<STREQUAL:${TOMAS_BINS},40>:TOMAS40>
         ""
 )
-if(${CLOUDJ})
-    add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
-endif()
+add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
 add_subdirectory(GEOS-Chem EXCLUDE_FROM_ALL)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update adds the [Cloud-J](https://github.com/geoschem/cloud-J/) photolysis library as a submodule with GC-Classic. It is stored alongside GEOS-Chem and HEMCO in the `src` folder. This PR should be merged with https://github.com/geoschem/geos-chem/pull/1522.

### Expected changes

See https://github.com/geoschem/geos-chem/pull/1522 for changes expected in GEOS-Chem when using Cloud-J to compute J-values.

### Reference(s)

Prather, M. J.: Photolysis rates in correlated overlapping cloud fields: Cloud-J 7.3c, Geosci. Model Dev., 8, 2587–2595, https://doi.org/10.5194/gmd-8-2587-2015, 2015.

### Related Github Issue(s)

https://github.com/geoschem/geos-chem/pull/1522