### PR TITLE
Fix problems with GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GEOS-Chem user manual
+    url: https://geos-chem.readthedocs.io/en/stable
+    about: Click this link to read the GEOS-Chem user manual.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
----
-name: Submit updates to the GCClassic superproject with a pull request
-labels: 'never stale'
-
----
-
 ### Name and Institution (Required)
 
 Name:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased 14.1.1]
+### Added
+- - Added `.github/ISSUE_TEMPLATE/config.yml` file w/ Github issue options
+
 ### Changed
-  - Simplified Github issue and pull request templates
+- The GitHub PR template is now named `./github/PULL_REQUEST_TEMPLATE.md`
 
 ## [14.1.0] - 2023-02-01
 ### Added


### PR DESCRIPTION
This PR fixes some problems with the GitHub issue and PR templates. Namely:

1. The PR template is now `.github/PULL_REQUEST_TEMPLATE.md`
2. Added `.github/ISSUE_TEMPLATE/config.yml` to prevent blank issues and add a link to the GC manual at RTD.

This is a zero-diff update, as only code in the .github folder was touched.