### PR TITLE
correct the wrong url of NCO

### DIFF
--- a/docs/source/gcc-guide/01-startup/packages-opt.rst
+++ b/docs/source/gcc-guide/01-startup/packages-opt.rst
@@ -51,7 +51,7 @@ output by GEOS-Chem). Ncview is very useful for debugging and development.
 nco
 ===
 `The netCDF operators (nco)
-<http://meteora.ucsd.edu/~pierce/ncview_home_page.html>`_ are
+<https://nco.sourceforge.net/>`_ are
 powerful command-line tools for editing and manipulating data in
 netCDF format.
 


### PR DESCRIPTION
correct the wrong url of NCO

### Name and Institution (Required)

Name: Bo Fu
Institution: Peking University

### Confirm you have reviewed the following documentation

- [y] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

There is a smaell mistake in the document of 'Optional but recommended software packages' section. **nco links to the webset of ncview**. 

### Expected changes

I just change the web link.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue(s)

Please link to the corresponding Github issue here. If fixing a bug, there should be an issue describing it with steps to reproduce.
