### PR TITLE
Update symbolic link from GCClassic root folder to the test folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 14.2.1]
+### Changed
+- `test` now points to `src/GEOS-Chem/test`
+
 ## [Unreleased 14.2.0]
 ### Changed
   - Updated GEOS-Chem submodule to 14.2.0

--- a/test
+++ b/test
@@ -1,1 +1,1 @@
-src/GEOS-Chem/test/GCClassic
+src/GEOS-Chem/test


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is a companion PR to https://github.com/geoschem/geos-chem/pull/1794.  This resets the `test` folder to the new path `src/GEOS-Chem/test` to be consistent with the changes made in the geoschem/geos-chem repo.

### Expected changes

This is a zero-diff update, as it only modifies a symbolic link.  No scientific changes are added.

### Reference(s)

N/A

### Related Github Issue(s)

- Merge after https://github.com/geoschem/geos-chem/pull/1794
- Fixes several issues in https://github.com/geoschem/geos-chem/issues/714
- The corresponding PR for GCHP is https://github.com/geoschem/GCHP/pull/327

Please link to the corresponding Github issue here. If fixing a bug, there should be an issue describing it with steps to reproduce.
