### PR TITLE
Removed BPCH_DIAG compilation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] -- TBD
 ### Removed
-- `BPCH_DIAG` configuration option
+- `BPCH_DIAG` configuration option and related ReadTheDocs documentation
 
 ## [14.3.0] - 2024-02-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] -- TBD
+### Removed
+- `BPCH_DIAG` configuration option
+
 ## [14.3.0] - 2024-02-07
 ### Changed
 - Updated GEOS-Chem submodule to 14.3.0

--- a/CMakeScripts/GC-ConfigureClassic.cmake
+++ b/CMakeScripts/GC-ConfigureClassic.cmake
@@ -50,19 +50,6 @@ function(configureGCClassic)
     gc_pretty_print(VARIABLE MECH OPTIONS "fullchem" "carbon" "Hg" "custom")
 
     #-------------------------------------------------------------------------
-    # Turn on bpch diagnostics?
-    #-------------------------------------------------------------------------
-    set(BPCH_DIAG "OFF" CACHE BOOL 
-        "Switch to enable GEOS-Chem's bpch diagnostics"
-    )
-    gc_pretty_print(VARIABLE BPCH_DIAG IS_BOOLEAN)
-    if(${BPCH_DIAG})
-        target_compile_definitions(GEOSChemBuildProperties
-	    INTERFACE BPCH_DIAG
-	)
-    endif()
-
-    #-------------------------------------------------------------------------
     # Set USE_REAL8 as cache variable so as to not override existing definition
     # See https://github.com/geoschem/geos-chem/issues/43.
     #-------------------------------------------------------------------------

--- a/docs/source/gcclassic-user-guide/compile-cmake.rst
+++ b/docs/source/gcclassic-user-guide/compile-cmake.rst
@@ -109,7 +109,6 @@ generate output similar to this:
    -- Found OpenMP: TRUE (found version "4.5")
    -- General settings:
      * MECH:         **fullchem**  carbon  Hg  custom
-     * BPCH_DIAG:    **ON**  OFF
      * USE_REAL8:    **ON**  OFF
      * SANITIZE:     ON  **OFF**
    -- Components:
@@ -275,26 +274,6 @@ options, unless you explicitly specify otherwise.
    .. option:: 40
 
       Use 40 size-resolved bins with TOMAS simulations.
-
-.. option:: BPCH_DIAG
-
-   Toggles the legacy binary punch diagnostics on.
-
-   .. attention::
-
-      This option is deprecated and will be removed soon.  Most
-      binary-punch format diagnostics have been replaced by
-      :ref:`netCDF-based History diagnostics <history-diagnostics>`.
-
-   Accepted values are:
-
-   .. option:: y
-
-      Activate legacy binary-punch diagnostics.
-
-   .. option:: n
-
-      Deactivate legacy binary-punch diagnostics. **(Default option)**
 
 .. option:: APM
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update
This PR is the companion to https://github.com/geoschem/geos-chem/pull/2166.  It removes the `BPCH_DIAG` CMake configuration option from `CMakeScripts/GC-ConfigureClassic.cmake`.

### Expected changes

This is a zero-diff update.  It does not contain any submodule hashes.  It should be merged into dev/14.4.0 following https://github.com/geoschem/geos-chem/pull/2166.

### Related Github Issue(s)

- https://github.com/geoschem/geos-chem/pull/2166
- https://github.com/geoschem/geos-chem/issues/82