### PR TITLE
Add GitHub action for compile-only integration tests

### DIFF
--- a/.github/workflows/gcclassic-compile-tests.yml
+++ b/.github/workflows/gcclassic-compile-tests.yml
@@ -30,4 +30,4 @@ jobs:
         run: |
           git submodule update --init --recursive
           cd test/integration/GCClassic
-          ./integrationTest.sh -d /test -s none -e ~/.bashrc
+          ./integrationTest.sh -d /GCC_it -t compile

--- a/.github/workflows/gcclassic-compile-tests.yml
+++ b/.github/workflows/gcclassic-compile-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Debug]
     env:
       CXX: g++
       CC: gcc
@@ -30,4 +30,5 @@ jobs:
         run: |
           git submodule update --init --recursive
           cd test/integration/GCClassic
-          ./integrationTest.sh -d /GCC_it -t compile
+          ./integrationTest.sh -d $HOME/compile-tests -t compile
+          cat $HOME/compile-tests/logs/results.compile.log

--- a/.github/workflows/gcclassic-compile-tests.yml
+++ b/.github/workflows/gcclassic-compile-tests.yml
@@ -1,0 +1,33 @@
+name: gcclassic-compile-tests
+
+on: [pull_request, push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  gnu:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+    env:
+      CXX: g++
+      CC: gcc
+      FC: gfortran
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libnetcdf-dev netcdf-bin libnetcdff-dev
+
+      - name: Compile-only tests
+        run: |
+          git submodule update --init --recursive
+          cd test/integration/GCClassic
+          ./integrationTest.sh -d /test -s none -e ~/.bashrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- GitHub action to perform compile-only integration tests
+
 ### Changed
 - Now use short submodule names (i.e. without the full path) in `.gitmodules`
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This PR adds a GitHub Action to invoke a compilation-only integration test every time a pull request or push is made to this repository.  

NOTE: This PR does not contain any submodule hashes.  It should be merged after https://github.com/geoschem/geos-chem/pull/2187 is merged into `dev/no-diff-to-benchmark` branch.

### Expected changes

This is a zero-diff update.  It will cause compile-only integration tests for GCClassic to be run.

### Related Github Issue(s)

- See https://github.com/geoschem/geos-chem/pull/2187
