### PR TITLE
Now use short submodule names in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
-[submodule "src/GEOS-Chem"]
+[submodule "GEOS-Chem"]
 	path = src/GEOS-Chem
 	url = https://github.com/geoschem/geos-chem.git
-[submodule "src/HEMCO"]
+[submodule "HEMCO"]
 	path = src/HEMCO
 	url = https://github.com/geoschem/hemco.git
-[submodule "docs/source/geos-chem-shared-docs"]
+[submodule "geos-chem-shared-docs"]
 	path = docs/source/geos-chem-shared-docs
 	url = https://github.com/geoschem/geos-chem-shared-docs.git
-[submodule "src/Cloud-J"]
+[submodule "Cloud-J"]
 	path = src/Cloud-J
 	url = https://github.com/geoschem/Cloud-J.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Now use short submodule names (i.e. without the full path) in `.gitmodules`
+
 ## [14.3.0] - 2024-02-07
 ### Changed
 - Updated GEOS-Chem submodule to 14.3.0


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [ ] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

This is a minor update that fixes some incorrect submodule names in the `.gitmodules` file.  We have changed:
```console
[submodule "src/GEOS-Chem"]
[submodule "src/HEMCO"]
[submodule "docs/source/geos-chem-shared-docs"]
[submodule "src/GEOS-Chem/Cloud-J"]
```
to
```console
[submodule "GEOS-Chem"]
[submodule "HEMCO"]
[submodule "geos-chem-shared-docs"]
[submodule "Cloud-J"]
```

### Expected changes
This is a zero-diff update.

### Related Github Issue(s)
NOTE: This PR should be merged immediately after:
- https://github.com/geoschem/geos-chem/pull/2154
- https://github.com/geoschem/cloud-j/pull/2