### PR TITLE
Remove obsolete options from CH4 menu in geoschem-config.rst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Now use short submodule names (i.e. without the full path) in `.gitmodules`
+- Remove obsolete CH4 menu options from config file documentation
 
 ## [14.3.0] - 2024-02-07
 ### Changed

--- a/docs/source/gcclassic-user-guide/geoschem-config.rst
+++ b/docs/source/gcclassic-user-guide/geoschem-config.rst
@@ -1609,51 +1609,8 @@ the inversion parameters that you specify.
      # ... preceding sub-sections omitted ...
 
      analytical_inversion:
-       activate: false
-       emission_perturbation: 1.0
-       state_vector_element_number: 0
-       use_emission_scale_factor: false
-       use_OH_scale_factors: false
        perturb_OH_boundary_conditions: false
        CH4_boundary_condition_ppb_increase_NSEW: [0.0, 0.0, 0.0, 0.0]
-
-.. option:: activate
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`) the
-   analytical inversion.
-
-   Default value: :literal:`false`
-
-.. option:: emission perturbation
-
-   Specifies a unitless factor by which emissions for this state
-   vector element will be perturbed.
-
-   Default value: :literal:`1.0` (no perturbation)
-
-.. option:: state_vector_element_number
-
-   Specifies the element of the state vector corresponding to this
-   simulation.
-
-   Default value: :literal:`0`
-
-.. option:: use_emission_scale_factor
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`)
-   scaling methane emissions by a fixed factor.  This scale factor is
-   specified in the :ref:`HEMCO_Config.rc <cfg-hco-cfg>` file.
-
-   Default value: :literal:`false`
-
-.. option:: use_oh_scale_factors
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`)
-   perturbation of OH in analytical inversions of methane.  The OH
-   scale factors are specified in the :literal:`OH_SF` entry of
-   :ref:`HEMCO_Config.rc <cfg-hco-cfg>` file.
-
-   Default value: :literal:`false`
 
 .. option:: perturb_CH4_boundary_conditions
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

 ### Describe the update

In pull request https://github.com/geoschem/geos-chem/pull/2218 several options were retired from the CH4 menu in geoschem_config.rc. These options were removed in favor of handling emissions perturbations and scale factors directly in HEMCO_Config.rc.

### Related Github Issue(s)

This should be merged alongside:
- https://github.com/geoschem/geos-chem/pull/2218
