### PR TITLE
New submodule: HETP aerosol thermodynamics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "Cloud-J"]
 	path = src/Cloud-J
 	url = https://github.com/geoschem/Cloud-J.git
+[submodule "src/HETerogeneous-vectorized-or-Parallel"]
+	path = src/HETP
+	url = https://github.com/geoschem/HETerogeneous-vectorized-or-Parallel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ## [Unreleased] -- TBD
+### Added
+- Added git submodule HETP for aerosol thermodynamics in GEOS-Chem
+
 ### Changed
 - Updated GEOS-Chem submodule to 14.4.0
 - Updated HEMCO submodule to 3.9.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ set(GCCLASSIC_WRAPPER TRUE)
 set(GC_EXTERNAL_CONFIG FALSE)
 set(HEMCO_EXTERNAL_CONFIG TRUE)
 set(CLOUDJ_EXTERNAL_CONFIG TRUE)
+set(HETP_EXTERNAL_CONFIG TRUE)
 
 #-----------------------------------------------------------------------------
 # Add the directory with source code

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ target_compile_definitions(HEMCOBuildProperties
         $<$<STREQUAL:${TOMAS_BINS},40>:TOMAS40>
         ""
 )
+add_subdirectory(HETP EXCLUDE_FROM_ALL)
 add_subdirectory(Cloud-J EXCLUDE_FROM_ALL)
 add_subdirectory(GEOS-Chem EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR adds the ISOROPPIA II aerosol thermodynamics package with [HETPv1.0](https://github.com/geoschem/HETerogeneous-vectorized-or-Parallel) as a new git submodule. From the HETP README:

> HETP is an aerosol thermodynamic equilibrium solver written in modern Fortran based on ISORROPIA II (which is written in FORTRAN 77).  HETP solves only the 'forward' metastable state of the NH4+/Na+/Ca2+/K+/Mg2+/SO42–/NO3–/Cl–/H2O system.  The main publication for HETP is avaiable online at:  https://gmd.copernicus.org/preprints/gmd-2023-159/.

Note that this PR can be merged prior to updates in GEOS-Chem to use HETP without issue. However, it is required before the updates to GEOS-Chem in PR https://github.com/geoschem/geos-chem/pull/2244.

### Expected changes

Preliminary 1-month full chemistry benchmarks comparing ISORROPIA with HETPv1.0 in GEOS-Chem are posted [here](https://ftp.as.harvard.edu/gcgrid/geos-chem/validation/isorropia_vs_hetp/1mon_fullchem/).

### Reference(s)

See https://gmd.copernicus.org/articles/17/2197/2024/gmd-17-2197-2024-discussion.html

### Related Github Issue(s)

- GEOS-Chem Issue: https://github.com/geoschem/geos-chem/issues/2235
- GEOS-Chem PR: https://github.com/geoschem/geos-chem/pull/2244
- GCHP PR: https://github.com/geoschem/GCHP/pull/408
