### PR TITLE
Removing unused options from carbon simulation (related to pull request #2266)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/GEOS-Chem"]
 	path = src/GEOS-Chem
-	url = https://github.com/geoschem/geos-chem.git
+	url = https://github.com/hannahnesser/geos-chem.git
 [submodule "src/HEMCO"]
 	path = src/HEMCO
 	url = https://github.com/geoschem/hemco.git

--- a/.release/changeVersionNumbers.sh
+++ b/.release/changeVersionNumbers.sh
@@ -91,6 +91,7 @@ function main() {
     files=(                          \
         "CHANGELOG.md"               \
         "src/GEOS-Chem/CHANGELOG.md" \
+        "src/GEOS-Chem/KPP/fullchem/CHANGELOG_fullchem.md" \
     )
 
     # Replace version numbers in files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased 14.3.0] - TBD
+## [14.3.0] - 2024-02-07
 ### Changed
 - Updated GEOS-Chem submodule to 14.3.0
 - Updated HEMCO submodule to 3.6.0

--- a/docs/source/gcclassic-user-guide/geoschem-config.rst
+++ b/docs/source/gcclassic-user-guide/geoschem-config.rst
@@ -1688,57 +1688,9 @@ for activating sources of :math:`CO_2`:
    CO2_simulation_options:
 
      sources:
-       fossil_fuel_emissions: true
-       ocean_exchange: true
-       balanced_biosphere_exchange: true
-       net_terrestrial_exchange: true
-       ship_emissions: true
-       aviation_emissions: true
        3D_chemical_oxidation_source: true
 
      # ... following sub-sections omitted ...
-
-.. option:: fossil_fuel_emissions
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`)
-   using :math:`CO_2` fossil fuel emissions as computed by HEMCO.
-
-   Default value: :literal:`true`
-
-.. option:: ocean_exchange
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`)
-   :math:`CO_2` ocean-air exchange.
-
-   Default value: :literal:`true`
-
-.. option:: balanced_biosphere_exchange
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`)
-   :math:`CO_2` balanced-biosphere exchange.
-
-   Default value: :literal:`true`
-
-.. option:: net_terrestrial_exchange
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`)
-   :math:`CO_2` net terrestrial exchange.
-
-   Default value: :literal:`true`
-
-.. option:: ship_emissions
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`) :math:`CO_2`
-   ship emissions as computed by HEMCO.
-
-   Default value: :literal:`true`
-
-.. option:: aviation_emissions
-
-   Activates (:literal:`true`) or deactivates (:literal:`false`) :math:`CO_2`
-   aviation emissions as computed by HEMCO.
-
-   Default value: :literal:`true`
 
 .. option:: 3D_chemical_oxidation_source
 
@@ -1772,18 +1724,8 @@ for activating tagged :math:`CO_2` species:
      # ... preceding sub-sections omitted ...
 
      tagged_species:
-       save_fossil_fuel_in_background: false
        tag_bio_and_ocean_CO2: false
        tag_land_fossil_fuel_CO2:
-       tag_global_ship_CO2: false
-       tag_global_aircraft_CO2: false
-
-.. option:: save_fossil_fuel_in_background
-
-   Activates (:code:`true`) or deactivates (:literal:`false`) saving the
-   :math:`CO_2` background.
-
-   Default value: :literal:`false`
 
 .. option:: tag_bio_and_ocean_CO2
 

--- a/docs/source/gcclassic-user-guide/geoschem-config.rst
+++ b/docs/source/gcclassic-user-guide/geoschem-config.rst
@@ -1725,7 +1725,7 @@ for activating tagged :math:`CO_2` species:
 
      tagged_species:
        tag_bio_and_ocean_CO2: false
-       tag_land_fossil_fuel_CO2:
+       tag_land_fossil_fuel_CO2: false
 
 .. option:: tag_bio_and_ocean_CO2
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Hannah Nesser
Institution: JPL

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/help-and-reference/CONTRIBUTING.html)

### Describe the update

Please see the related pull request: https://github.com/geoschem/geos-chem/pull/2266

I removed the following options from the CO2 simulation (including from the carbon single tracer simulation) because they were unused: LFOSSIL, LBIODIURNAL, LBIONETCLIM, LOCEAN, LSHIP, LPLANE, LFFBKGRD, LSHIPTAG, LPLANETAG

I also added a default value for tag_land_fossil_fuel_CO2: false, which was previously missing.

### Expected changes

This should not change any model operations since all removed options were unused.

### Reference(s)

None

### Related Github Issue(s)

