### PR TITLE
Throw a CMake error if FAST-JX is used for any KPP mechanism except Hg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- CMake now throws an error if FAST-JX is used with any other mechanism than Hg
+
 ## [14.4.1] - 2024-06-28
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run

--- a/CMakeScripts/GC-ConfigureClassic.cmake
+++ b/CMakeScripts/GC-ConfigureClassic.cmake
@@ -192,12 +192,18 @@ function(configureGCClassic)
     #-------------------------------------------------------------------------
     # Use Fast-JX rather than Cloud-J?
     #-------------------------------------------------------------------------
-
     set(FASTJX OFF CACHE BOOL
         "Switch to use legacy FAST-JX in GEOS-Chem"
     )
     gc_pretty_print(VARIABLE FASTJX IS_BOOLEAN)
     if(${FASTJX})
+        #---------------------------------------------------------------------
+        # Throw an error unless we are using the Hg mechanism,
+        # The fullchem & custom mechanisms now use Cloud-J!
+        if(NOT ${MECH} MATCHES "Hg")
+          message(FATAL_ERROR "FASTJX can only be used with the Hg mechanism!")
+        endif()
+        #---------------------------------------------------------------------
         target_compile_definitions(GEOSChemBuildProperties
             INTERFACE FASTJX
         )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR adds an error trap that causes CMake to throw an error if the FASTJX compile option is selected for any mechanism except Hg.

### Expected changes
Configuring with the `-DFASTJX=y` option now throws an error message such as:
```console
CMake Error: The source directory "/n/holyscratch01/jacob_lab/ryantosca/tests/nodiff/gc237x/test_fullchem" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
[holy8a24501 build]$ cmake ../CodeDir -DFASTJX=y
-- The Fortran compiler identification is GNU 10.2.0
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /n/sw/helmod-rocky8/apps/Core/gcc/10.2.0-fasrc01/bin/gfortran - skipped
=================================================================
GCClassic 14.4.1 (superproject wrapper)
Current status: 14.4.1-6-gdb89d20
=================================================================
-- Found NetCDF: /n/sw/helmod-rocky8/apps/MPI/gcc/10.2.0-fasrc01/openmpi/4.1.0-fasrc01/netcdf-fortran/4.5.3-fasrc01/lib/libnetcdff.so  
-- Useful CMake variables:
  + CMAKE_PREFIX_PATH:    /n/sw/helmod-rocky8/apps/MPI/gcc/10.2.0-fasrc01/openmpi/4.1.0-fasrc01/netcdf-c/4.8.0-fasrc01
  ...             /n/sw/helmod-rocky8/apps/MPI/gcc/10.2.0-fasrc01/openmpi/4.1.0-fasrc01/netcdf-fortran/4.5.3-fasrc01
  ...             /n/sw/helmod-rocky8/apps/MPI/gcc/10.2.0-fasrc01/openmpi/4.1.0-fasrc01/netcdf-c/4.8.0-fasrc01
  ...             /n/sw/helmod-rocky8/apps/MPI/gcc/10.2.0-fasrc01/openmpi/4.1.0-fasrc01/netcdf-fortran/4.5.3-fasrc01
  + CMAKE_BUILD_TYPE:     Release
-- Run directory setup:

-- Threading:
  * OMP:          ON  OFF
-- Found OpenMP_Fortran: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- General settings:
  * MECH:         fullchem  carbon  Hg  custom
  * USE_REAL8:    ON  OFF
  * SANITIZE:     ON  OFF
-- Components:
  * TOMAS:        ON  OFF
  * TOMAS_BINS:   NA  15  40
  * APM:          ON  OFF
  * RRTMG:        ON  OFF
  * GTMM:         ON  OFF
  * HCOSA:        ON  OFF
  * LUO_WETDEP:   ON  OFF
  * FASTJX:       ON  OFF
CMake Error at CMakeScripts/GC-ConfigureClassic.cmake:204 (message):
  FASTJX can only be used with the Hg mechanism!
Call Stack (most recent call first):
  CMakeLists.txt:226 (configureGCClassic)


-- Configuring incomplete, errors occurred!
See also "/n/holyscratch01/jacob_lab/ryantosca/tests/nodiff/gc237x/test_fullchem/build/CMakeFiles/CMakeOutput.log".
```
### Related Github Issue
- This PR was a result of discussion about https://github.com/geoschem/geos-chem/pull/2371
- Also see https://github.com/geoschem/GCHP/pull/426