### PR TITLE
Feature/kpp standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- Added code to `src/CMakeLists.txt` to build & install the KPP standalone executable when `fullchem` or `custom` mechanisms are selected
+
 ### Changed
 - Updated GEOS-Chem to 14.5.0
 - Updated HEMCO to 3.10.0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,32 @@ set_target_properties(${EXE_FILE_NAME}
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+#-----------------------------------------------------------------------------
+# Define the KPP standalone executable:
+# 1. Specify a cache variable with the default target name
+# 2. Specify the location of the main program
+# 3. Specify libraries that the main program depends on
+# 4. Store the binary exectuable file in the bin folder (pre-install)
+#
+# At present build KPP standalone only for fullchem or custom mechanisms.
+#-----------------------------------------------------------------------------
+if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
+  set(KPPSA_FILE_NAME kpp_standalone CACHE STRING
+    "Default name for the KPP standalone executable file")
+  mark_as_advanced(KPPSA_FILE_NAME)
+
+  add_executable(${KPPSA_FILE_NAME}
+    GEOS-Chem/KPP/standalone/kpp_standalone.F90
+  )
+  target_link_libraries(${KPPSA_FILE_NAME}
+    PUBLIC
+    KPPStandalone
+  )
+  set_target_properties(${KPPSA_FILE_NAME}
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+endif()
 
 #-----------------------------------------------------------------------------
 # When "make install" is run, copy the target to the destination folder
@@ -71,6 +97,7 @@ foreach(INSTALL_PATH ${COMBINED_INSTALL_DIRS})
       # Installation path is a GEOS-Chem run directory,
       # Therefore we will install the executable there.
       install(TARGETS ${EXE_FILE_NAME} RUNTIME DESTINATION ${INSTALL_PATH})
+      install(TARGETS ${KPPSA_FILE_NAME} RUNTIME DESTINATION ${INSTALL_PATH})
     endif()
 
 endforeach()


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to https://github.com/geoschem/geos-chem/pull/2483.  We have added code to the `src/CMakeLists.txt ` file to build the KPP standalone executable when compiling GEOS-Chem with the fullchem mechanism (`-DMECH=fullchem`) or the custom mechanism (`-DMECH=custom`).  

### Expected changes
The KPP standalone executable file will be built and copied to the GEOS-Chem run directory.

### Related Github Issue
- See https://github.com/geoschem/geos-chem/pull/2483