### PR TITLE
Add KPP standalone model to GEOS-Chem 14.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ This file documents all notable changes to the GEOS-Chem Classic wrapper reposit
 - src/HEMCO/CHANGELOG.md
 - src/Cloud-J/CHANGELOG.md
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - TBD
+### Added
+- Added code to `src/CMakeLists.txt` to build & install the KPP standalone executable when `fullchem` or `custom` mechanisms are selected
 
 ## [14.5.0] - 2024-11-08
 ### Changed

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,33 @@ set_target_properties(${EXE_FILE_NAME}
 )
 
 #-----------------------------------------------------------------------------
+# Define the KPP standalone executable:
+# 1. Specify a cache variable with the default target name
+# 2. Specify the location of the main program
+# 3. Specify libraries that the main program depends on
+# 4. Store the binary exectuable file in the bin folder (pre-install)
+#
+# At present build KPP standalone only for fullchem or custom mechanisms.
+#-----------------------------------------------------------------------------
+if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
+  set(KPPSA_FILE_NAME kpp_standalone CACHE STRING
+    "Default name for the KPP standalone executable file")
+  mark_as_advanced(KPPSA_FILE_NAME)
+
+  add_executable(${KPPSA_FILE_NAME}
+    GEOS-Chem/KPP/standalone/kpp_standalone.F90
+  )
+  target_link_libraries(${KPPSA_FILE_NAME}
+    PUBLIC
+    KPPStandalone
+  )
+  set_target_properties(${KPPSA_FILE_NAME}
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+endif()
+
+#-----------------------------------------------------------------------------
 # When "make install" is run, copy the target to the destination folder
 # (which is typically one directory higher than the CMake build folder)
 #-----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,7 @@ foreach(INSTALL_PATH ${COMBINED_INSTALL_DIRS})
       # Installation path is a GEOS-Chem run directory,
       # Therefore we will install the executable there.
       install(TARGETS ${EXE_FILE_NAME} RUNTIME DESTINATION ${INSTALL_PATH})
+      install(TARGETS ${KPPSA_FILE_NAME} RUNTIME DESTINATION ${INSTALL_PATH})
     endif()
 
 endforeach()


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR brings the updates that were formerly in geos-chem PR #2382 and geos-chem PR #2383 into the dev/no-diff-to-benchmark branch. These will ship in 14.5.1.  It modifies the `src/CMakeLists.txt` file to build the KPP standalone file when compiled with `-DMECH=fullchem` or `-DMECH=custom`.

### Expected changes
This is a zero-diff update

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue
- https://github.com/geoschem/geos-chem/pull/2588
- https://github.com/geoschem/GCHP/pull/463
- https://github.com/geoschem/geos-chem/pull/2482
- https://github.com/geoschem/geos-chem/pull/2483
