### PR TITLE
Fix configuration error in GEOS-Chem Classic continuous integration tests on Azure

### DIFF
--- a/.ci-pipelines/build-matrix.yml
+++ b/.ci-pipelines/build-matrix.yml
@@ -46,7 +46,7 @@ container: $[ variables['containerImage'] ]
 # Try building GEOS-Chem (this is run for each "matrix" entry above)
 steps:
 - checkout: self
-  submodules: true
+  submodules: recursive
 - script: |
     . /opt/spack/share/spack/setup-env.sh
     export CC=gcc

--- a/.ci-pipelines/quick-build.yml
+++ b/.ci-pipelines/quick-build.yml
@@ -31,7 +31,7 @@ container: geoschem/buildmatrix:netcdf-ubuntu
 # Try building GEOS-Chem
 steps:
 - checkout: self
-  submodules: true
+  submodules: recursive
 - script: |
     . /opt/spack/share/spack/setup-env.sh
     export CC=gcc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - Added code to `src/CMakeLists.txt` to build & install the KPP standalone executable when `fullchem` or `custom` mechanisms are selected
 
+### Changed
+- Changed `submodules: true` to `submodules: recursive` in `.ci-pipelines/*.yml` files, which will fetch all levels of submodules in Azure CI tests.
+
 ## [14.5.0] - 2024-11-08
 ### Changed
 - Updated GEOS-Chem to 14.5.0


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR resolves the following error:
```console
=================================================================
GEOS-Chem 14.5.0 (science codebase)
Current status: 14.6.0-alpha.0-84-g990e8e408
=================================================================
CMake Error at src/GEOS-Chem/KPP/CMakeLists.txt:9 (add_subdirectory):
  The source directory

    /__w/1/s/src/GEOS-Chem/KPP/standalone

  does not contain a CMakeLists.txt file.


Creating /__w/1/s/src/GEOS-Chem/Interfaces/GCClassic/gc_classic_version.H
-- Configuring incomplete, errors occurred!
See also "/__w/1/s/build/CMakeFiles/CMakeOutput.log".
+ make -j
make: *** No targets specified and no makefile found.  Stop.
```
in GEOS-Chem Classic continuous integration tests on Azure Dev Pipelines.   

This error was introduced when the https://geos-chem/geoschem/KPP-Standalone repo was introduced as a submodule to the GEOS-Chem Science Codebase,  The solution is to edit the configuration files in the `./ci-pipelines` folder to specify recursive submodule fetching by changing:
```yaml
# Try building GEOS-Chem
steps:
- checkout: self
  submodules: true
```
to
```yaml
# Try building GEOS-Chem
steps:
- checkout: self
  submodules: recursive
```

### Expected changes
With this fix, Azure continuous integration tests for GEOS-Chem Classic should run to completion.

### Related Github Issue

The KPP standalone was introduced into GEOS-Chem Classic in these PRs:
- #73
- https://github.com/geoschem/geos-chem/pull/2588
