### PR TITLE
Do not build KPP-Standalone executable unless specifically requested at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased] - TBD
 ### Changed
 - Bumped `jinja2` to version 3.1.5 in `docs/requirements.txt` to fix a security issue
+- Changed the build sequence so that the KPP-Standalone is only built when configuring with `-DKPPSA=y`
 
 ## [14.5.1] - 2025-01-10
 ### Added

--- a/CMakeScripts/GC-ConfigureClassic.cmake
+++ b/CMakeScripts/GC-ConfigureClassic.cmake
@@ -176,6 +176,14 @@ function(configureGCClassic)
     gc_pretty_print(VARIABLE HCOSA IS_BOOLEAN)
 
     #-------------------------------------------------------------------------
+    # Build the KPP-Standalone?
+    #-------------------------------------------------------------------------
+    set(KPPSA OFF CACHE BOOL
+      "Switch to build the KPP-Standalone Box Model"
+    )
+    gc_pretty_print(VARIABLE KPP_STANDALONE IS_BOOLEAN)
+
+    #-------------------------------------------------------------------------
     # Build Luo et al wetdep scheme?
     # (Currently a research option... turn OFF by default)
     #-------------------------------------------------------------------------
@@ -208,7 +216,7 @@ function(configureGCClassic)
             INTERFACE FASTJX
         )
     endif()
-
+    
     #-------------------------------------------------------------------------
     # Export the following variables to GEOS-Chem directory's scope
     #-------------------------------------------------------------------------

--- a/CMakeScripts/GC-ConfigureClassic.cmake
+++ b/CMakeScripts/GC-ConfigureClassic.cmake
@@ -181,7 +181,7 @@ function(configureGCClassic)
     set(KPPSA OFF CACHE BOOL
       "Switch to build the KPP-Standalone Box Model"
     )
-    gc_pretty_print(VARIABLE KPP_STANDALONE IS_BOOLEAN)
+    gc_pretty_print(VARIABLE KPPSA IS_BOOLEAN)
 
     #-------------------------------------------------------------------------
     # Build Luo et al wetdep scheme?

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,8 @@ set_target_properties(${EXE_FILE_NAME}
 )
 
 #-----------------------------------------------------------------------------
+# If GEOS-Chem Classic has been configured with -DKPPSA=y, then:
+#
 # Define the KPP standalone executable:
 # 1. Specify a cache variable with the default target name
 # 2. Specify the location of the main program
@@ -51,26 +53,28 @@ set_target_properties(${EXE_FILE_NAME}
 # This should now fix the issue reported by @msulprizio in:
 #   https://github.com/geoschem/GCClassic/issues/78
 #-----------------------------------------------------------------------------
-set(KPPSA_FILE_NAME kpp_standalone CACHE STRING
-  "Default name for the KPP standalone executable file")
-mark_as_advanced(KPPSA_FILE_NAME)
-add_executable(${KPPSA_FILE_NAME}
-  GEOS-Chem/KPP/standalone/kpp_standalone.F90
-)
-if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
-  target_link_libraries(${KPPSA_FILE_NAME}
-    PUBLIC
-    KPPStandalone
-  )
-  set_target_properties(${KPPSA_FILE_NAME}
-    PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-else()
-  set_target_properties(${KPPSA_FILE_NAME}
-    PROPERTIES
-    EXCLUDE_FROM_ALL TRUE
-  )
+if (${KPPSA})
+  set(KPPSA_FILE_NAME kpp_standalone CACHE STRING
+    "Default name for the KPP standalone executable file")
+  mark_as_advanced(KPPSA_FILE_NAME)
+  add_executable(${KPPSA_FILE_NAME}
+    GEOS-Chem/KPP/standalone/kpp_standalone.F90
+    )
+  if("${MECH}" STREQUAL fullchem OR "${MECH}" STREQUAL custom)
+    target_link_libraries(${KPPSA_FILE_NAME}
+      PUBLIC
+      KPPStandalone
+      )
+    set_target_properties(${KPPSA_FILE_NAME}
+      PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+      )
+  else()
+    set_target_properties(${KPPSA_FILE_NAME}
+      PROPERTIES
+      EXCLUDE_FROM_ALL TRUE
+      )
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR adds CMake updates so that the KPP-Standalone executable will not be built unless the user configures with the `-DKPPSA=y` option.

### Expected changes
This is a zero-diff update 

### Related Github Issue
- Must be merged with https://github.com/geoschem/geos-chem/pull/2712

