### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,13 +71,22 @@ set(GEOSChem_Fortran_FLAGS_DEBUG_Intel
     -g -O0 "SHELL:-check arg_temp_created" "SHELL:-debug all" -fpe0 -ftrapuv -check,bounds
     CACHE STRING "GEOSChem compiler flags for build type Debug with Intel compilers"
 )
-
-set(GEOSChem_Fortran_FLAGS_GNU
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+    # arm based processors only support mcmodels of large small tiny
+    set(GEOSChem_Fortran_FLAGS_GNU
+    -cpp -w -std=legacy -fautomatic -fno-align-commons
+    -fconvert=big-endian -fno-range-check -mcmodel=small
+    -fbacktrace -g -DLINUX_GFORTRAN -ffree-line-length-none
+    CACHE STRING "GEOSChem compiler flags for all build types with GNU compilers"
+    )
+else()
+    set(GEOSChem_Fortran_FLAGS_GNU
     -cpp -w -std=legacy -fautomatic -fno-align-commons
     -fconvert=big-endian -fno-range-check -mcmodel=medium
     -fbacktrace -g -DLINUX_GFORTRAN -ffree-line-length-none
     CACHE STRING "GEOSChem compiler flags for all build types with GNU compilers"
-)
+    )
+endif()
 set(GEOSChem_Fortran_FLAGS_RELEASE_GNU
    -O3 -funroll-loops
    CACHE STRING "GEOSChem compiler flags for build type Release with GNU compilers"


### PR DESCRIPTION
Enable GCClassic to compile on MacOS using gfortran

### Name and Institution (Required)

Name: Lee Murray
Institution: U Rochester

### Describe the update

mcmodel only has tiny small and large options for MacOS

### Expected changes

GEOS-Chem should be able to compile on MacOS architectures now. HEMCO and Cloud-J already have this logic, but it will need to be added to HETP as well. 