### PR TITLE
Update CMakeLists.txt to use mcmodel=small when compiling GEOS-Chem Classic on ARM processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Updated `CMakeLists.txt` to set compilation option `mcmodel=small` for ARM-based CPUs, as ARM does not support `mcmodel=medium`
+
 ## [14.6.1] - 2025-05-29
 ### Added
 - Added RTD documentation updates for GEOS-Chem 14.6.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,22 @@ set(GEOSChem_DETECTED_FORTRAN_COMPILER_VERSION ${CMAKE_Fortran_COMPILER_VERSION}
     CACHE INTERNAL "Logging the compiler version to CMakeCache.txt"
 )
 
-set(GEOSChem_Fortran_FLAGS_Intel
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+  # ARM based processors support mcmodel=large, mcmodel=small, mcmodel=tiny
+  set(GEOSChem_Fortran_FLAGS_Intel
+    -cpp -w -auto -noalign "SHELL:-convert big_endian" "SHELL:-fp-model source"
+    -mcmodel=small -shared-intel -traceback -DLINUX_IFORT
+    CACHE STRING "GEOSChem compiler flags for all build types with Intel compilers"
+    )
+else()
+  # x86_64 processors also support mcmodel=medium
+  set(GEOSChem_Fortran_FLAGS_Intel
     -cpp -w -auto -noalign "SHELL:-convert big_endian" "SHELL:-fp-model source"
     -mcmodel=medium -shared-intel -traceback -DLINUX_IFORT
     CACHE STRING "GEOSChem compiler flags for all build types with Intel compilers"
-)
+    )
+endif()
+  
 set(GEOSChem_Fortran_FLAGS_RELEASE_Intel
    -O2
     CACHE STRING "GEOSChem compiler flags for build type Release with Intel compilers"
@@ -72,12 +83,23 @@ set(GEOSChem_Fortran_FLAGS_DEBUG_Intel
     CACHE STRING "GEOSChem compiler flags for build type Debug with Intel compilers"
 )
 
-set(GEOSChem_Fortran_FLAGS_GNU
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+  # ARM based processors support mcmodel=large, mcmodel=small, mcmodel=tiny
+  set(GEOSChem_Fortran_FLAGS_GNU
+    -cpp -w -std=legacy -fautomatic -fno-align-commons
+    -fconvert=big-endian -fno-range-check -mcmodel=small
+    -fbacktrace -g -DLINUX_GFORTRAN -ffree-line-length-none
+    CACHE STRING "GEOSChem compiler flags for all build types with GNU compilers"
+    )
+else()
+  # x86_64 processors also support mcmodel=medium
+  set(GEOSChem_Fortran_FLAGS_GNU
     -cpp -w -std=legacy -fautomatic -fno-align-commons
     -fconvert=big-endian -fno-range-check -mcmodel=medium
     -fbacktrace -g -DLINUX_GFORTRAN -ffree-line-length-none
     CACHE STRING "GEOSChem compiler flags for all build types with GNU compilers"
-)
+    )
+endif()
 set(GEOSChem_Fortran_FLAGS_RELEASE_GNU
    -O3 -funroll-loops
    CACHE STRING "GEOSChem compiler flags for build type Release with GNU compilers"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR supersedes #89 by @ltmurray.  It adds if blocks to the locations where `GEOSChem_Fortran_Flags_Intel` and `GEOSChem_Fortran_Flags_GNU` variables are defined, so that `mcmodel=small` is used when compiling on ARM processors.  The ARM processors do not support `mcmodel=medium`.

### Expected changes
This should allow GEOS-Chem Classic to build on ARM processors.  No changes are made to compilation on other types of processors (e.g. x86_64).