### PR TITLE
Add -DDEBUG to Intel and GNU debug compiler flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- Added `-DDEBUG` flag to `GEOSChem_Fortran_FLAGS_DEBUG_Intel` and `GEOSChem_Fortran_FLAGS_DEBUG_GNU` to toggle debug-only code
+
 ### Changed
 - Updated `CMakeLists.txt` to set compilation option `mcmodel=small` for ARM-based CPUs, as ARM does not support `mcmodel=medium`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ set(GEOSChem_Fortran_FLAGS_RELWITHDEBINFO_Intel
     CACHE STRING "GEOSChem compiler flags for build type RelWithdDebInfo with Intel compilers"
 )
 set(GEOSChem_Fortran_FLAGS_DEBUG_Intel
-    -g -O0 "SHELL:-check arg_temp_created" "SHELL:-debug all" -fpe0 -ftrapuv -check,bounds
+    -g -O0 "SHELL:-check arg_temp_created" "SHELL:-debug all" -fpe0 -ftrapuv -check,bounds -DDEBUG
     CACHE STRING "GEOSChem compiler flags for build type Debug with Intel compilers"
 )
 
@@ -111,7 +111,7 @@ set(GEOSChem_Fortran_FLAGS_RELWITHDEBINFO_GNU
 set(GEOSChem_Fortran_FLAGS_DEBUG_GNU
     -g -O0 -Wall -Wextra -Wconversion -Warray-temporaries
     -fcheck=array-temps -ffpe-trap=invalid,zero,overflow -finit-real=snan
-    -fcheck=bounds -fcheck=pointer
+    -fcheck=bounds -fcheck=pointer -DDEBUG
     CACHE STRING "GEOSChem compiler flags for build type Debug with GNU compilers"
 )
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR adds the `-DDEBUG` option to the list of compiler flags that get selected when `-DCMAKE_BUILD_TYPE=Debug`.  This can be used to toggle warning statements or other code that should only execute when the GEOS-Chem Classic is built with the debugging flags turned on.

### Expected changes
This is a no-diff-to-benchmark update.

### Related Github Issue
- Should have been merged alongside [geos-chem #2915](https://github.com/geoschem/geos-chem/pull/2915) but wasn't
