### PR TITLE
Include additional Cmake options in summarize_build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Added CMake options MECH, USE_REAL8, and SANITIZE to `CMakeScripts/summarize_build`
+
 ## [14.7.0] - 2026-02-06
 ### Added
 - Added "GEOS-Chem Classic vertical grids" supplemental guide in ReadTheDocs

--- a/CMakeScripts/summarize_build
+++ b/CMakeScripts/summarize_build
@@ -63,6 +63,12 @@ print_item_highlight "HEMCO_Fortran_FLAGS_${COMPILER_ID}" $(scrape_cache HEMCO_F
 print_item_highlight "HEMCO_Fortran_FLAGS_${BUILD_TYPE_UPPER}_${COMPILER_ID}" $(scrape_cache HEMCO_Fortran_FLAGS_${BUILD_TYPE_UPPER}_${COMPILER_ID})
 echo "" 
 
+echo "## GEOS-Chem General Settings"
+print_item_highlight MECH $(scrape_cache MECH)
+print_item_highlight USE_REAL8 $(scrape_cache USE_REAL8)
+print_item_highlight SANITIZE $(scrape_cache SANITIZE)
+echo ""
+
 echo "## GEOS-Chem Components Settings"
 print_item_highlight TOMAS $(scrape_cache TOMAS)
 print_item_highlight TOMAS_BINS $(scrape_cache TOMAS_BINS)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The `MECH`, `USE_REAL8`, and `SANITIZE` CMake build option settings are now printed to screen via the summarize_build script.

### Expected changes

This is a zero difference update to GEOS-Chem simulations. It will simply print additional information to the screen when users run the `summarize_build` script within a GEOS-Chem run directory.

### Related Github Issue

- https://github.com/geoschem/geos-chem/issues/3153#issuecomment-3718892812
