### PR TITLE
Run the gcclassic-compiler-tests GitHub Action with GCC versions 10 through 16

### DIFF
--- a/.github/workflows/gcclassic-compile-tests.yml
+++ b/.github/workflows/gcclassic-compile-tests.yml
@@ -18,11 +18,13 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug]
+        gcc-version: [10, 11, 12, 13, 14, 15, 16]
     env:
       CXX: g++
       CC: gcc
       FC: gfortran
 
+    name: Compile-only tests (${{ matrix.build_type }}, GCC ${{ matrix.gcc-version }})
     steps:
       - name: Checkout code
         with:
@@ -31,8 +33,22 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo grep -rl 'packages.microsoft.com' /etc/apt/sources.list.d/ | xargs -r sudo rm -f
           sudo apt update -y
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt update -y
+          sudo apt install -y gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }} gfortran-${{ matrix.gcc-version }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc-version }} 100 \
+             --slave /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.gcc-version }} \
+             --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${{ matrix.gcc-version }}
           sudo apt install -y libnetcdf-dev netcdf-bin libnetcdff-dev
+
+      - name: Verify environment
+        run: |
+          gcc --version
+          g++ --version
+          gfortran --version
 
       - name: Compile-only tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Updated `.github/workflows/gcclassic-compile-tests` to run as a build matrix using GCC compiler versions 10 through 16
+
 ## [14.7.1] - 2026-04-13
 ### Added
 - Added CMake options MECH, USE_REAL8, and SANITIZE to `CMakeScripts/summarize_build`


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

@lizziel wrote in https://github.com/geoschem/geos-chem/issues/3355:

> NASA GMAO alerted me that MAPL3, which will be released as part of GCHP 15.0, will deprecate support for GNU compilers prior to 14.4. They currently have MAPL3 working with the following GNU versions, which we should make the new recommended GNU compilers for GEOS-Chem in the 15.0 release.
>
>14.4
>15.2
>16.1

In this PR we have updated the "gcclassic-compile-tests" GitHub action to run as a matrix using GCC versions 10 through 16.  This should help us detect instances where legacy code in the GEOS-Chem "science codebase" repository fails to build with the newer GCC compilers.

We should also try to add a similar build test to the GCHP repo.

### Expected changes
The gcclassic-compile-tests now will execute using several GCC compiler versions and not just one version.  Otherwise this is a no-diff-to-benchmark update.

### Related Github Issue
- See https://github.com/geoschem/geos-chem/issues/3355