### PR TITLE
Request 48 vcpus for AWS instance used for GC-Classic benchmark runs

### DIFF
--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -74,7 +74,10 @@ jobs:
       - name: Trigger Step Function
         env:
           # Set config options for aws cli
-          NUM_CORES: 62
+	  # Note that 96 cores are requested but this does not necessarily mean
+	  # 96 will be used. See gc-cloud-infrastructure for actual number of
+	  # cores used for the GC-Classic benchmark runs, set as OMP_NUM_THREADS.
+          NUM_CORES: 96
           EC2_TYPE: SPOT # SPOT or DEMAND
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cloud-benchmarking-workflow.yml
+++ b/.github/workflows/cloud-benchmarking-workflow.yml
@@ -74,10 +74,10 @@ jobs:
       - name: Trigger Step Function
         env:
           # Set config options for aws cli
-	  # Note that 96 cores are requested but this does not necessarily mean
-	  # 96 will be used. See gc-cloud-infrastructure for actual number of
-	  # cores used for the GC-Classic benchmark runs, set as OMP_NUM_THREADS.
-          NUM_CORES: 96
+          # Require 48 vcpus in AWS instance used for GC-Clasic benchmark runs.
+          # See gc-cloud-infrastructure for actual number of cores used for
+          # GC-Classic benchmark runs, set as OMP_NUM_THREADS.
+          NUM_CORES: 48
           EC2_TYPE: SPOT # SPOT or DEMAND
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Changed number of requested cores for benchmarking on AWS from 62 to 96, of which only 48 will be used
+
 ## [14.7.1] - 2026-04-13
 ### Added
 - Added CMake options MECH, USE_REAL8, and SANITIZE to `CMakeScripts/summarize_build`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
 ### Changed
-- Changed number of requested cores for benchmarking on AWS from 62 to 96, of which only 48 will be used
+- Require 48 vcpus for AWS instance used for GC-Classic benchmark runs
 
 ## [14.7.1] - 2026-04-13
 ### Added


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

Request 48 vcpus in AWS instance used for GC-Classic benchmark runs. We are changing how many cores are used in benchmarking so that GCHP and GC-Classic use the same number of cores. This enables an apples-to-apples timing comparison.

**This update should be merged at the same time as the following PRs:**
- https://github.com/geoschem/GCHP/pull/563
- https://github.com/geoschem/gc-cloud-infrastructure/pull/64

### Expected changes

This is a no diff update for all simulations. 

### Reference(s)

None

### Related Github Issue

None
